### PR TITLE
Correctly resolve addon names from error messages

### DIFF
--- a/WagoAnalytics.lua
+++ b/WagoAnalytics.lua
@@ -42,7 +42,7 @@ do
 	-- isSimple 3 state: True is simple, False is pcall, Nil is not simple
 	local function handleError(errorMessage, isSimple, errorObj)
 		errorMessage = tostring(errorMessage)
-		local wagoID = GetAddOnMetadata(match(errorMessage, "AddOns\\([^\\]+)\\") or "Unknown", "X-Wago-ID")
+		local wagoID = GetAddOnMetadata(match(errorMessage, "AddOns[\\/]([^\\/]+)[\\/]") or "Unknown", "X-Wago-ID")
 		if not wagoID or not registeredAddons[wagoID] then
 			return
 		end


### PR DESCRIPTION
Fixes #32. Since 10.0 the error message format was slightly changed to use "/" delimiters for path segments rather than "\".

For compatibility with Classic Era, the pattern for extracting the addon name now accepts both delimiters.