### PR TITLE
Avoid errors when querying unknown addons

### DIFF
--- a/WagoAnalytics.lua
+++ b/WagoAnalytics.lua
@@ -43,8 +43,8 @@ do
 	-- isSimple 3 state: True is simple, False is pcall, Nil is not simple
 	local function handleError(errorMessage, isSimple, errorObj)
 		errorMessage = tostring(errorMessage)
-		local wagoID = GetAddOnMetadata(match(errorMessage, "AddOns[\\/]([^\\/]+)[\\/]") or "Unknown", "X-Wago-ID")
-		if not wagoID or not registeredAddons[wagoID] then
+		local ok, wagoID = pcall(GetAddOnMetadata, match(errorMessage, "AddOns[\\/]([^\\/]+)[\\/]") or "Unknown", "X-Wago-ID")
+		if not ok or not wagoID or not registeredAddons[wagoID] then
 			return
 		end
 		local addonObj = registeredAddons[wagoID]


### PR DESCRIPTION
Patch 10.1 applied an extra subtle change to C_AddOns.GetAddOnMetadata that results in it now erroring if the supplied addon name does not exist.

If the analytics error handler fails to extract an addon name from the error message it ends up passing "Unknown" as the addon name, which is almost always never going to be an installed addon - and as such will raise an error.

This can be trivially tested from the chat frame via the following, which will result in two errors - one for the call we're making ourselves, and one from within analytics directly.

    /run C_AddOns.GetAddOnMetadata("oops")

```
1x WagoAnalytics/WagoAnalytics.lua:46: bad argument #1 to 'GetAddOnMetadata' (Invalid AddOn name Unknown. - Usage: local value = C_AddOns.GetAddOnMetadata(name, variable))
[string "=[C]"]: ?
[string "@WagoAnalytics/WagoAnalytics.lua"]:46: in function <WagoAnalytics/WagoAnalytics.lua:44>
[string "@WagoAnalytics/WagoAnalytics.lua"]:127: in function <WagoAnalytics/WagoAnalytics.lua:126>
[string "=[C]"]: ?
[string "@BugSack/Libs/CallbackHandler-1.0-8/CallbackHandler-1.0.lua"]:19: in function <...ack/Libs/CallbackHandler-1.0/CallbackHandler-1.0.lua:15>
[string "@BugSack/Libs/CallbackHandler-1.0-8/CallbackHandler-1.0.lua"]:54: in function `Fire'
[string "@!BugGrabber/BugGrabber.lua"]:108: in function <!BugGrabber/BugGrabber.lua:106>
[string "@!BugGrabber/BugGrabber.lua"]:341: in function <!BugGrabber/BugGrabber.lua:255>
[string "=[C]"]: ?
[string "=[C]"]: in function `GetAddOnMetadata'
[string "C_AddOns.GetAddOnMetadata("oops")"]:1: in main chunk
[string "=[C]"]: in function `RunScript'
[string "@FrameXML/ChatFrame.lua"]:2174: in function `?'
[string "@FrameXML/ChatFrame.lua"]:5236: in function <FrameXML/ChatFrame.lua:5182>
[string "=[C]"]: in function `ChatEdit_ParseText'
[string "@FrameXML/ChatFrame.lua"]:4894: in function `ChatEdit_SendText'
[string "@FrameXML/ChatFrame.lua"]:4930: in function `ChatEdit_OnEnterPressed'
[string "*ChatFrame.xml:141_OnEnterPressed"]:1: in function <[string "*ChatFrame.xml:141_OnEnterPressed"]:1>

Locals:
(*temporary) = "Unknown"
(*temporary) = "X-Wago-ID"
(*temporary) = "Invalid AddOn name Unknown. - Usage: local value = C_AddOns.GetAddOnMetadata(name, variable)"
```

Wrapping things up with a protected call barrier resolves this issue.